### PR TITLE
grpc-json transcoder: not to handle grpc-status greater than Grpc::St…

### DIFF
--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
@@ -491,7 +491,7 @@ Http::FilterTrailersStatus JsonTranscoderFilter::encodeTrailers(Http::HeaderMap&
   } else {
     response_headers_->Status()->value(Grpc::Utility::grpcToHttpStatus(grpc_status.value()));
     if (!is_trailers_only_response) {
-      response_headers_->setGrpcStatus(enumToInt(grpc_status.value()));
+      response_headers_->setGrpcStatus(grpc_status.value());
     }
   }
 


### PR DESCRIPTION
…atus::MaximumValid as invalid status (#8820)

Description: 
If returned grpc header/trailer includes invalid status code that is greater than `Grpc::Status::MaximumValid`, encoded json doesn't include `grpc-status` field when `convert-grpc-status` is false.

Risk Level: Low
Testing: unit test
Docs Changes: none
Release Notes: none
Fixes #8053 

Signed-off-by: Shikugawa <rei@tetrate.io>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
