### PR TITLE
build: several fix for C++17 compatibility (#9102)

### DIFF
--- a/include/envoy/http/header_map.h
+++ b/include/envoy/http/header_map.h
@@ -181,9 +181,13 @@ public:
    */
   Type type() const { return type_; }
 
-  bool operator==(const char* rhs) const { return getStringView() == absl::string_view(rhs); }
+  bool operator==(const char* rhs) const {
+    return getStringView() == absl::NullSafeStringView(rhs);
+  }
   bool operator==(absl::string_view rhs) const { return getStringView() == rhs; }
-  bool operator!=(const char* rhs) const { return getStringView() != absl::string_view(rhs); }
+  bool operator!=(const char* rhs) const {
+    return getStringView() != absl::NullSafeStringView(rhs);
+  }
   bool operator!=(absl::string_view rhs) const { return getStringView() != rhs; }
 
 private:

--- a/source/common/http/http1/header_formatter.cc
+++ b/source/common/http/http1/header_formatter.cc
@@ -1,5 +1,7 @@
 #include "common/http/http1/header_formatter.h"
 
+#include <string>
+
 namespace Envoy {
 namespace Http {
 namespace Http1 {

--- a/source/extensions/filters/http/common/aws/credentials_provider_impl.h
+++ b/source/extensions/filters/http/common/aws/credentials_provider_impl.h
@@ -10,6 +10,8 @@
 
 #include "extensions/filters/http/common/aws/credentials_provider.h"
 
+#include "absl/strings/string_view.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {
@@ -78,8 +80,8 @@ private:
 class TaskRoleCredentialsProvider : public MetadataCredentialsProviderBase {
 public:
   TaskRoleCredentialsProvider(Api::Api& api, const MetadataFetcher& metadata_fetcher,
-                              const std::string& credential_uri,
-                              const std::string& authorization_token = std::string())
+                              absl::string_view credential_uri,
+                              absl::string_view authorization_token = {})
       : MetadataCredentialsProviderBase(api, metadata_fetcher), credential_uri_(credential_uri),
         authorization_token_(authorization_token) {}
 
@@ -118,8 +120,7 @@ public:
 
   virtual CredentialsProviderSharedPtr createTaskRoleCredentialsProvider(
       Api::Api& api, const MetadataCredentialsProviderBase::MetadataFetcher& metadata_fetcher,
-      const std::string& credential_uri,
-      const std::string& authorization_token = std::string()) const PURE;
+      absl::string_view credential_uri, absl::string_view authorization_token = {}) const PURE;
 
   virtual CredentialsProviderSharedPtr createInstanceProfileCredentialsProvider(
       Api::Api& api,
@@ -150,8 +151,7 @@ private:
 
   CredentialsProviderSharedPtr createTaskRoleCredentialsProvider(
       Api::Api& api, const MetadataCredentialsProviderBase::MetadataFetcher& metadata_fetcher,
-      const std::string& credential_uri,
-      const std::string& authorization_token = std::string()) const override {
+      absl::string_view credential_uri, absl::string_view authorization_token = {}) const override {
     return std::make_shared<TaskRoleCredentialsProvider>(api, metadata_fetcher, credential_uri,
                                                          authorization_token);
   }

--- a/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
+++ b/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
@@ -48,7 +48,8 @@ Config::Config(Stats::Scope& scope, uint32_t max_client_hello_size)
   SSL_CTX_set_tlsext_servername_callback(
       ssl_ctx_.get(), [](SSL* ssl, int* out_alert, void*) -> int {
         Filter* filter = static_cast<Filter*>(SSL_get_app_data(ssl));
-        filter->onServername(SSL_get_servername(ssl, TLSEXT_NAMETYPE_host_name));
+        filter->onServername(
+            absl::NullSafeStringView(SSL_get_servername(ssl, TLSEXT_NAMETYPE_host_name)));
 
         // Return an error to stop the handshake; we have what we wanted already.
         *out_alert = SSL_AD_USER_CANCELLED;

--- a/test/common/http/http2/http2_frame.h
+++ b/test/common/http/http2/http2_frame.h
@@ -69,7 +69,7 @@ public:
   enum class ResponseStatus { Unknown, Ok, NotFound };
 
   // Methods for creating HTTP2 frames
-  static Http2Frame makePingFrame(absl::string_view data = nullptr);
+  static Http2Frame makePingFrame(absl::string_view data = {});
   static Http2Frame makeEmptySettingsFrame(SettingsFlags flags = SettingsFlags::None);
   static Http2Frame makeEmptyHeadersFrame(uint32_t stream_index,
                                           HeadersFlags flags = HeadersFlags::None);

--- a/test/extensions/filters/http/common/aws/credentials_provider_impl_test.cc
+++ b/test/extensions/filters/http/common/aws/credentials_provider_impl_test.cc
@@ -340,21 +340,14 @@ public:
   class MockCredentialsProviderChainFactories : public CredentialsProviderChainFactories {
   public:
     MOCK_CONST_METHOD0(createEnvironmentCredentialsProvider, CredentialsProviderSharedPtr());
-    MOCK_CONST_METHOD4(createTaskRoleCredentialsProviderMock,
+    MOCK_CONST_METHOD4(createTaskRoleCredentialsProvider,
                        CredentialsProviderSharedPtr(
                            Api::Api&, const MetadataCredentialsProviderBase::MetadataFetcher&,
-                           const std::string&, const std::string&));
+                           absl::string_view, absl::string_view));
     MOCK_CONST_METHOD2(createInstanceProfileCredentialsProvider,
                        CredentialsProviderSharedPtr(
                            Api::Api&,
                            const MetadataCredentialsProviderBase::MetadataFetcher& fetcher));
-
-    CredentialsProviderSharedPtr createTaskRoleCredentialsProvider(
-        Api::Api& api, const MetadataCredentialsProviderBase::MetadataFetcher& metadata_fetcher,
-        const std::string& credential_uri, const std::string& authorization_token) const override {
-      return createTaskRoleCredentialsProviderMock(api, metadata_fetcher, credential_uri,
-                                                   authorization_token);
-    }
   };
 
   Event::SimulatedTimeSystem time_system_;
@@ -381,22 +374,22 @@ TEST_F(DefaultCredentialsProviderChainTest, MetadataNotDisabled) {
 
 TEST_F(DefaultCredentialsProviderChainTest, RelativeUri) {
   TestEnvironment::setEnvVar("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", "/path/to/creds", 1);
-  EXPECT_CALL(factories_, createTaskRoleCredentialsProviderMock(
-                              Ref(*api_), _, "169.254.170.2:80/path/to/creds", ""));
+  EXPECT_CALL(factories_, createTaskRoleCredentialsProvider(Ref(*api_), _,
+                                                            "169.254.170.2:80/path/to/creds", ""));
   DefaultCredentialsProviderChain chain(*api_, DummyMetadataFetcher(), factories_);
 }
 
 TEST_F(DefaultCredentialsProviderChainTest, FullUriNoAuthorizationToken) {
   TestEnvironment::setEnvVar("AWS_CONTAINER_CREDENTIALS_FULL_URI", "http://host/path/to/creds", 1);
-  EXPECT_CALL(factories_, createTaskRoleCredentialsProviderMock(Ref(*api_), _,
-                                                                "http://host/path/to/creds", ""));
+  EXPECT_CALL(factories_,
+              createTaskRoleCredentialsProvider(Ref(*api_), _, "http://host/path/to/creds", ""));
   DefaultCredentialsProviderChain chain(*api_, DummyMetadataFetcher(), factories_);
 }
 
 TEST_F(DefaultCredentialsProviderChainTest, FullUriWithAuthorizationToken) {
   TestEnvironment::setEnvVar("AWS_CONTAINER_CREDENTIALS_FULL_URI", "http://host/path/to/creds", 1);
   TestEnvironment::setEnvVar("AWS_CONTAINER_AUTHORIZATION_TOKEN", "auth_token", 1);
-  EXPECT_CALL(factories_, createTaskRoleCredentialsProviderMock(
+  EXPECT_CALL(factories_, createTaskRoleCredentialsProvider(
                               Ref(*api_), _, "http://host/path/to/creds", "auth_token"));
   DefaultCredentialsProviderChain chain(*api_, DummyMetadataFetcher(), factories_);
 }

--- a/test/extensions/filters/http/common/aws/credentials_provider_test.cc
+++ b/test/extensions/filters/http/common/aws/credentials_provider_test.cc
@@ -16,7 +16,7 @@ TEST(Credentials, Default) {
 }
 
 TEST(Credentials, AllNull) {
-  const auto c = Credentials(nullptr, nullptr, nullptr);
+  const auto c = Credentials({}, {}, {});
   EXPECT_FALSE(c.accessKeyId().has_value());
   EXPECT_FALSE(c.secretAccessKey().has_value());
   EXPECT_FALSE(c.sessionToken().has_value());


### PR DESCRIPTION
Risk Level: Low
Testing: run asan test with --cxxopt=-std=c++17

Signed-off-by: Lizan Zhou <lizan@tetrate.io>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
