### PR TITLE
thrift-proxy: fix crash (#9089)

### DIFF
--- a/source/extensions/filters/network/thrift_proxy/router/router_impl.h
+++ b/source/extensions/filters/network/thrift_proxy/router/router_impl.h
@@ -206,6 +206,7 @@ private:
 
     FilterStatus start();
     void resetStream();
+    void releaseConnection(bool close);
 
     // Tcp::ConnectionPool::Callbacks
     void onPoolFailure(Tcp::ConnectionPool::PoolFailureReason reason,


### PR DESCRIPTION
After Router::onEvent() handles a local or remote close, do not attempt
to close the connection a second time during Router::onDestroy().

Risk Level: low
Testing: unit/integration tests
Doc Changes: n/a
Release Notes: n/a
Fixes: #9037

Signed-off-by: Raul Gutierrez Segales <rgs@pinterest.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
