### PR TITLE
test flake: fix header casing integration test (#9104)

### DIFF
--- a/test/integration/header_casing_integration_test.cc
+++ b/test/integration/header_casing_integration_test.cc
@@ -1,5 +1,3 @@
-#include <chrono>
-
 #include "envoy/config/bootstrap/v2/bootstrap.pb.h"
 
 #include "common/buffer/buffer_impl.h"
@@ -51,8 +49,7 @@ TEST_P(HeaderCasingIntegrationTest, VerifyCasedHeaders) {
   tcp_client->write(request, false);
 
   Envoy::FakeRawConnectionPtr upstream_connection;
-  ASSERT_TRUE(
-      fake_upstreams_[0]->waitForRawConnection(upstream_connection, std::chrono::milliseconds(10)));
+  ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(upstream_connection));
 
   // Verify that the upstream request has proper cased headers.
   std::string upstream_request;


### PR DESCRIPTION
Given that most other integration tests don't set a timeout for
an upstream connection that is expected to succeed, remove the
timeout.

Risk Level: low, test-only
Testing: 1000 repetitions
Doc Changes: n/a
Release Notes: n/a
Fixes: #8899

Signed-off-by: Stephan Zuercher <zuercher@gmail.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
