### PR TITLE
repokitteh: pin modules to git SHAs. (#9131)

### DIFF
--- a/repokitteh.star
+++ b/repokitteh.star
@@ -1,9 +1,9 @@
-use("github.com/repokitteh/modules/assign.star")
-use("github.com/repokitteh/modules/review.star")
-use("github.com/repokitteh/modules/wait.star")
-use("github.com/repokitteh/modules/circleci.star", secret_token=get_secret('circle_token'))
+use("github.com/repokitteh/modules/assign.star#22520d03464dd9503e036c7fa365c427723c4aaf")
+use("github.com/repokitteh/modules/review.star#22520d03464dd9503e036c7fa365c427723c4aaf")
+use("github.com/repokitteh/modules/wait.star#22520d03464dd9503e036c7fa365c427723c4aaf")
+use("github.com/repokitteh/modules/circleci.star#22520d03464dd9503e036c7fa365c427723c4aaf", secret_token=get_secret('circle_token'))
 use(
-  "github.com/repokitteh/modules/ownerscheck.star",
+  "github.com/repokitteh/modules/ownerscheck.star#22520d03464dd9503e036c7fa365c427723c4aaf",
   paths=[
     {
       "owner": "envoyproxy/api-shepherds!",


### PR DESCRIPTION
The main goal here is to improve stability via hermetic description of RK dependencies.

Signed-off-by: Harvey Tuch <htuch@google.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
