### PR TITLE
tools: move clang_tools under @envoy_dev (#9249)

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,2 +1,3 @@
 api
 examples/grpc-bridge/script
+tools/clang_tools

--- a/bazel/dev_binding.bzl
+++ b/bazel/dev_binding.bzl
@@ -1,0 +1,40 @@
+def _default_envoy_dev_impl(ctxt):
+    if "LLVM_CONFIG" in ctxt.os.environ:
+        ctxt.file("WORKSPACE", "")
+        ctxt.file("BUILD.bazel", "")
+        ctxt.symlink(ctxt.path(ctxt.attr.envoy_root).dirname.get_child("tools").get_child("clang_tools"), "clang_tools")
+
+_default_envoy_dev = repository_rule(
+    implementation = _default_envoy_dev_impl,
+    attrs = {
+        "envoy_root": attr.label(default = "@envoy//:BUILD"),
+    },
+)
+
+def _clang_tools_impl(ctxt):
+    if "LLVM_CONFIG" in ctxt.os.environ:
+        llvm_config_path = ctxt.os.environ["LLVM_CONFIG"]
+        exec_result = ctxt.execute([llvm_config_path, "--includedir"])
+        if exec_result.return_code != 0:
+            fail(llvm_config_path + " --includedir returned %d" % exec_result.return_code)
+        clang_tools_include_path = exec_result.stdout.rstrip()
+        exec_result = ctxt.execute([llvm_config_path, "--libdir"])
+        if exec_result.return_code != 0:
+            fail(llvm_config_path + " --libdir returned %d" % exec_result.return_code)
+        clang_tools_lib_path = exec_result.stdout.rstrip()
+        for include_dir in ["clang", "clang-c", "llvm", "llvm-c"]:
+            ctxt.symlink(clang_tools_include_path + "/" + include_dir, include_dir)
+        ctxt.symlink(clang_tools_lib_path, "lib")
+        ctxt.symlink(Label("@envoy_dev//clang_tools/support:BUILD.prebuilt"), "BUILD")
+
+_clang_tools = repository_rule(
+    implementation = _clang_tools_impl,
+    environ = ["LLVM_CONFIG"],
+)
+
+def envoy_dev_binding():
+    # Treat the Envoy developer tools that require llvm as an external repo, this avoids
+    # breaking bazel build //... when llvm is not installed.
+    if "envoy_dev" not in native.existing_rules().keys():
+        _default_envoy_dev(name = "envoy_dev")
+        _clang_tools(name = "clang_tools")

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,4 +1,5 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load(":dev_binding.bzl", "envoy_dev_binding")
 load(":genrule_repository.bzl", "genrule_repository")
 load("@envoy_api//bazel:envoy_http_archive.bzl", "envoy_http_archive")
 load(":repository_locations.bzl", "REPOSITORY_LOCATIONS")
@@ -89,28 +90,10 @@ def _go_deps(skip_targets):
         _repository_impl("io_bazel_rules_go")
         _repository_impl("bazel_gazelle")
 
-def _clang_tools_impl(ctxt):
-    if "LLVM_CONFIG" in ctxt.os.environ:
-        llvm_config_path = ctxt.os.environ["LLVM_CONFIG"]
-        exec_result = ctxt.execute([llvm_config_path, "--includedir"])
-        if exec_result.return_code != 0:
-            fail(llvm_config_path + " --includedir returned %d" % exec_result.return_code)
-        clang_tools_include_path = exec_result.stdout.rstrip()
-        exec_result = ctxt.execute([llvm_config_path, "--libdir"])
-        if exec_result.return_code != 0:
-            fail(llvm_config_path + " --libdir returned %d" % exec_result.return_code)
-        clang_tools_lib_path = exec_result.stdout.rstrip()
-        for include_dir in ["clang", "clang-c", "llvm", "llvm-c"]:
-            ctxt.symlink(clang_tools_include_path + "/" + include_dir, include_dir)
-        ctxt.symlink(clang_tools_lib_path, "lib")
-        ctxt.symlink(Label("//tools/clang_tools/support:BUILD.prebuilt"), "BUILD")
-
-_clang_tools = repository_rule(
-    implementation = _clang_tools_impl,
-    environ = ["LLVM_CONFIG"],
-)
-
 def envoy_dependencies(skip_targets = []):
+    # Setup Envoy developer tools.
+    envoy_dev_binding()
+
     # Treat Envoy's overall build config as an external repo, so projects that
     # build Envoy as a subcomponent can easily override the config.
     if "envoy_build_config" not in native.existing_rules().keys():
@@ -129,8 +112,6 @@ def envoy_dependencies(skip_targets = []):
         name = "ssl",
         actual = "@envoy//bazel:boringssl",
     )
-
-    _clang_tools(name = "clang_tools")
 
     # The long repo names (`com_github_fmtlib_fmt` instead of `fmtlib`) are
     # semi-standard in the Bazel community, intended to avoid both duplicate

--- a/tools/clang_tools/README.md
+++ b/tools/clang_tools/README.md
@@ -26,7 +26,7 @@ Assuming that `CC` and `CXX` already point at Clang, you should be able to build
 with:
 
 ```console
-bazel build //tools/clang_tools/syntax_only
+bazel build @envoy_dev//clang_tools/syntax_only
 ```
 
 To run `libtooling` based tools against Envoy, you will need to first generate a
@@ -42,7 +42,7 @@ tools/gen_compilation_database.py --run_bazel_build --include_headers
 Finally, the tool can be run against source files in the Envoy tree:
 
 ```console
-bazel-bin/tools/clang_tools/syntax_only/syntax_only \
+bazel-bin/external/envoy_dev/clang_tools/syntax_only/syntax_only \
   source/common/common/logger.cc
 ```
 

--- a/tools/clang_tools/syntax_only/BUILD
+++ b/tools/clang_tools/syntax_only/BUILD
@@ -1,4 +1,4 @@
-load("//tools/clang_tools/support:clang_tools.bzl", "envoy_clang_tools_cc_binary")
+load("//clang_tools/support:clang_tools.bzl", "envoy_clang_tools_cc_binary")
 
 licenses(["notice"])  # Apache 2
 


### PR DESCRIPTION
Fixes regression in gen_compilation_database introduced in #8597, this causes unpleasant errors if a developer has not configured LLVM_CONFIG. The solution is to move developer tools into an `@envoy_api` like local external repository called `@envoy_dev`.

Risk level: Low
Testing: Manual, with LLVM_CONFIG set/unset.

Signed-off-by: Harvey Tuch <htuch@google.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
