### PR TITLE
ci, windows: Get ninja from github.com/ninja-build (#9320)

### DIFF
--- a/ci/windows_ci_setup.ps1
+++ b/ci/windows_ci_setup.ps1
@@ -2,11 +2,34 @@
 # The list of installed software can be found at:
 # https://github.com/Microsoft/azure-pipelines-image-generation/blob/master/images/win/Vs2019-Server2019-Readme.md
 
-mkdir "$env:TOOLS_BIN_DIR"
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+function Unzip
+{
+    param([string]$zipfile, [string]$outpath)
 
+    [System.IO.Compression.ZipFile]::ExtractToDirectory($zipfile, $outpath)
+}
+
+function Checksum
+{
+    param([string]$filepath, [string]$expected, [string]$algorithm)
+
+    $actual = Get-FileHash -Path $filePath -Algorithm $algorithm;
+    if ($actual.Hash -eq $expected) {
+        Write-Host "$filepath is valid";
+    } else {
+        Write-Host "$filepath is invalid, expected: $expected, but got: $actual";
+        exit 1
+    }
+}
+
+mkdir "$env:TOOLS_BIN_DIR"
 $wc = New-Object System.Net.WebClient
 $wc.DownloadFile("https://github.com/bazelbuild/bazelisk/releases/download/v1.0/bazelisk-windows-amd64.exe", "$env:TOOLS_BIN_DIR\bazel.exe")
+$wc.DownloadFile("https://github.com/ninja-build/ninja/releases/download/v1.9.0/ninja-win.zip", "$env:TOOLS_BIN_DIR\ninja-win.zip")
 
-# Install ninja.
-$choco = "$Env:ProgramData/chocolatey/choco.exe"
-iex "$choco install -y -f --acceptlicense --no-progress ninja"
+# Check the SHA256 file hash of each downloaded file.
+Checksum $env:TOOLS_BIN_DIR\bazel.exe 96395ee9e3fb9f4499fcaffa8a94dd72b0748f495f366bc4be44dbf09d6827fc SHA256
+Checksum $env:TOOLS_BIN_DIR\ninja-win.zip 2d70010633ddaacc3af4ffbd21e22fae90d158674a09e132e06424ba3ab036e9 SHA256
+
+Unzip "$env:TOOLS_BIN_DIR\ninja-win.zip" "$env:TOOLS_BIN_DIR"


### PR DESCRIPTION
This patch installs ninja from github.com/ninja-build/ninja releases since installing from chocolatey.org sometimes gives error install like the following:

Error retrieving packages from source 'https://chocolatey.org/api/v2/':
 Could not connect to the feed specified at 'https://chocolatey.org/api/v2/'. Please verify that the package source (located in the Package Manager Settings) is valid and ensure your network connectivity.
ninja not installed. The package was not found with the source(s) listed.
 Source(s): 'https://chocolatey.org/api/v2/'
 NOTE: When you specify explicit sources, it overrides default sources.
If the package version is a prerelease and you didn't specify `--pre`,
 the package may not be found.
Please see https://chocolatey.org/docs/troubleshooting for more 
 assistance.
This also adds SHA256 verification for the downloaded bazelisk and ninja archives.

Risk Level: Low
Testing: CI
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Dhi Aurrahman <dio@tetrate.io>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
