### PR TITLE
router: Add support for per-route configurable maximum number of inte…

### DIFF
--- a/api/envoy/api/v2/route/route_components.proto
+++ b/api/envoy/api/v2/route/route_components.proto
@@ -518,7 +518,7 @@ message CorsPolicy {
   core.RuntimeFractionalPercent shadow_enabled = 10;
 }
 
-// [#next-free-field: 31]
+// [#next-free-field: 32]
 message RouteAction {
   enum ClusterNotFoundResponseCode {
     // HTTP status code - 503 Service Unavailable.
@@ -874,6 +874,22 @@ message RouteAction {
   repeated UpgradeConfig upgrade_configs = 25;
 
   InternalRedirectAction internal_redirect_action = 26;
+
+  // An internal redirect is handled, iff the number of previous internal redirects that a
+  // downstream request has encountered is lower than this value, and
+  // :ref:`internal_redirect_action <envoy_api_field_route.RouteAction.internal_redirect_action>`
+  // is set to :ref:`HANDLE_INTERNAL_REDIRECT
+  // <envoy_api_enum_value_route.RouteAction.InternalRedirectAction.HANDLE_INTERNAL_REDIRECT>`
+  // In the case where a downstream request is bounced among multiple routes by internal redirect,
+  // the first route that hits this threshold, or has
+  // :ref:`internal_redirect_action <envoy_api_field_route.RouteAction.internal_redirect_action>`
+  // set to
+  // :ref:`PASS_THROUGH_INTERNAL_REDIRECT
+  // <envoy_api_enum_value_route.RouteAction.InternalRedirectAction.PASS_THROUGH_INTERNAL_REDIRECT>`
+  // will pass the redirect back to downstream.
+  //
+  // If not specified, at most one redirect will be followed.
+  google.protobuf.UInt32Value max_internal_redirects = 31;
 
   // Indicates that the route has a hedge policy. Note that if this is set,
   // it'll take precedence over the virtual host level hedge policy entirely

--- a/api/envoy/config/route/v3alpha/route_components.proto
+++ b/api/envoy/config/route/v3alpha/route_components.proto
@@ -487,7 +487,7 @@ message CorsPolicy {
   core.v3alpha.RuntimeFractionalPercent shadow_enabled = 10;
 }
 
-// [#next-free-field: 31]
+// [#next-free-field: 32]
 message RouteAction {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.route.RouteAction";
 
@@ -852,6 +852,23 @@ message RouteAction {
   repeated UpgradeConfig upgrade_configs = 25;
 
   InternalRedirectAction internal_redirect_action = 26;
+
+  // An internal redirect is handled, iff the number of previous internal redirects that a
+  // downstream request has encountered is lower than this value, and
+  // :ref:`internal_redirect_action
+  // <envoy_api_field_config.route.v3alpha.RouteAction.internal_redirect_action>` is set to
+  // :ref:`HANDLE_INTERNAL_REDIRECT
+  // <envoy_api_enum_value_config.route.v3alpha.RouteAction.InternalRedirectAction.HANDLE_INTERNAL_REDIRECT>`
+  // In the case where a downstream request is bounced among multiple routes by internal redirect,
+  // the first route that hits this threshold, or has
+  // :ref:`internal_redirect_action
+  // <envoy_api_field_config.route.v3alpha.RouteAction.internal_redirect_action>` set to
+  // :ref:`PASS_THROUGH_INTERNAL_REDIRECT
+  // <envoy_api_enum_value_config.route.v3alpha.RouteAction.InternalRedirectAction.PASS_THROUGH_INTERNAL_REDIRECT>`
+  // will pass the redirect back to downstream.
+  //
+  // If not specified, at most one redirect will be followed.
+  google.protobuf.UInt32Value max_internal_redirects = 31;
 
   // Indicates that the route has a hedge policy. Note that if this is set,
   // it'll take precedence over the virtual host level hedge policy entirely

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -39,6 +39,7 @@ Version history
 * router: added support for percentage-based :ref:`retry budgets <envoy_api_field_cluster.CircuitBreakers.Thresholds.retry_budget>`
 * router: allow using a :ref:`query parameter <envoy_api_field_route.RouteAction.HashPolicy.query_parameter>` for HTTP consistent hashing.
 * router: exposed DOWNSTREAM_REMOTE_ADDRESS as custom HTTP request/response headers.
+* router: added support for :ref:`max_internal_redirects <envoy_api_field_route.RouteAction.max_internal_redirects>` for configurable maximum internal redirect hops.
 * router: skip the Location header when the response code is not a 201 or a 3xx.
 * router: added :ref:`auto_sni <envoy_api_field_core.UpstreamHttpProtocolOptions.auto_sni>` to support setting SNI to transport socket for new upstream connections based on the downstream HTTP host/authority header.
 * server: added the :option:`--disable-extensions` CLI option, to disable extensions at startup.

--- a/generated_api_shadow/envoy/api/v2/route/route_components.proto
+++ b/generated_api_shadow/envoy/api/v2/route/route_components.proto
@@ -518,7 +518,7 @@ message CorsPolicy {
   core.RuntimeFractionalPercent shadow_enabled = 10;
 }
 
-// [#next-free-field: 31]
+// [#next-free-field: 32]
 message RouteAction {
   enum ClusterNotFoundResponseCode {
     // HTTP status code - 503 Service Unavailable.
@@ -874,6 +874,22 @@ message RouteAction {
   repeated UpgradeConfig upgrade_configs = 25;
 
   InternalRedirectAction internal_redirect_action = 26;
+
+  // An internal redirect is handled, iff the number of previous internal redirects that a
+  // downstream request has encountered is lower than this value, and
+  // :ref:`internal_redirect_action <envoy_api_field_route.RouteAction.internal_redirect_action>`
+  // is set to :ref:`HANDLE_INTERNAL_REDIRECT
+  // <envoy_api_enum_value_route.RouteAction.InternalRedirectAction.HANDLE_INTERNAL_REDIRECT>`
+  // In the case where a downstream request is bounced among multiple routes by internal redirect,
+  // the first route that hits this threshold, or has
+  // :ref:`internal_redirect_action <envoy_api_field_route.RouteAction.internal_redirect_action>`
+  // set to
+  // :ref:`PASS_THROUGH_INTERNAL_REDIRECT
+  // <envoy_api_enum_value_route.RouteAction.InternalRedirectAction.PASS_THROUGH_INTERNAL_REDIRECT>`
+  // will pass the redirect back to downstream.
+  //
+  // If not specified, at most one redirect will be followed.
+  google.protobuf.UInt32Value max_internal_redirects = 31;
 
   // Indicates that the route has a hedge policy. Note that if this is set,
   // it'll take precedence over the virtual host level hedge policy entirely

--- a/generated_api_shadow/envoy/config/route/v3alpha/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v3alpha/route_components.proto
@@ -545,7 +545,7 @@ message CorsPolicy {
   core.v3alpha.RuntimeFractionalPercent shadow_enabled = 10;
 }
 
-// [#next-free-field: 31]
+// [#next-free-field: 32]
 message RouteAction {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.route.RouteAction";
 
@@ -926,6 +926,23 @@ message RouteAction {
   repeated UpgradeConfig upgrade_configs = 25;
 
   InternalRedirectAction internal_redirect_action = 26;
+
+  // An internal redirect is handled, iff the number of previous internal redirects that a
+  // downstream request has encountered is lower than this value, and
+  // :ref:`internal_redirect_action
+  // <envoy_api_field_config.route.v3alpha.RouteAction.internal_redirect_action>` is set to
+  // :ref:`HANDLE_INTERNAL_REDIRECT
+  // <envoy_api_enum_value_config.route.v3alpha.RouteAction.InternalRedirectAction.HANDLE_INTERNAL_REDIRECT>`
+  // In the case where a downstream request is bounced among multiple routes by internal redirect,
+  // the first route that hits this threshold, or has
+  // :ref:`internal_redirect_action
+  // <envoy_api_field_config.route.v3alpha.RouteAction.internal_redirect_action>` set to
+  // :ref:`PASS_THROUGH_INTERNAL_REDIRECT
+  // <envoy_api_enum_value_config.route.v3alpha.RouteAction.InternalRedirectAction.PASS_THROUGH_INTERNAL_REDIRECT>`
+  // will pass the redirect back to downstream.
+  //
+  // If not specified, at most one redirect will be followed.
+  google.protobuf.UInt32Value max_internal_redirects = 31;
 
   // Indicates that the route has a hedge policy. Note that if this is set,
   // it'll take precedence over the virtual host level hedge policy entirely

--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -775,6 +775,12 @@ public:
   virtual InternalRedirectAction internalRedirectAction() const PURE;
 
   /**
+   * @returns the threshold of number of previously handled internal redirects, for this route to
+   * stop handle internal redirects.
+   */
+  virtual uint32_t maxInternalRedirects() const PURE;
+
+  /**
    * @return std::string& the name of the route.
    */
   virtual const std::string& routeName() const PURE;

--- a/include/envoy/stream_info/BUILD
+++ b/include/envoy/stream_info/BUILD
@@ -32,3 +32,11 @@ envoy_cc_library(
     external_deps = ["abseil_optional"],
     deps = ["//source/common/protobuf"],
 )
+
+envoy_cc_library(
+    name = "uint32_accessor_interface",
+    hdrs = ["uint32_accessor.h"],
+    deps = [
+        ":filter_state_interface",
+    ],
+)

--- a/include/envoy/stream_info/uint32_accessor.h
+++ b/include/envoy/stream_info/uint32_accessor.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "envoy/common/pure.h"
+#include "envoy/stream_info/filter_state.h"
+
+namespace Envoy {
+namespace StreamInfo {
+
+/**
+ * A FilterState object that tracks a single uint32_t value.
+ */
+class UInt32Accessor : public FilterState::Object {
+public:
+  /**
+   * Increments the tracked value by 1.
+   */
+  virtual void increment() PURE;
+
+  /**
+   * @return the tracked value.
+   */
+  virtual uint32_t value() const PURE;
+};
+
+} // namespace StreamInfo
+} // namespace Envoy

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -272,6 +272,7 @@ private:
     Router::InternalRedirectAction internalRedirectAction() const override {
       return Router::InternalRedirectAction::PassThrough;
     }
+    uint32_t maxInternalRedirects() const override { return 1; }
     const std::string& routeName() const override { return route_name_; }
     std::unique_ptr<const HashPolicyImpl> hash_policy_;
     static const NullHedgePolicy hedge_policy_;

--- a/source/common/router/BUILD
+++ b/source/common/router/BUILD
@@ -291,6 +291,7 @@ envoy_cc_library(
         "//source/common/network:application_protocol_lib",
         "//source/common/network:transport_socket_options_lib",
         "//source/common/stream_info:stream_info_lib",
+        "//source/common/stream_info:uint32_accessor_lib",
         "//source/common/tracing:http_tracer_lib",
         "//source/common/upstream:load_balancer_lib",
         "@envoy_api//envoy/extensions/filters/http/router/v3alpha:pkg_cc_proto",

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -286,7 +286,9 @@ RouteEntryImplBase::RouteEntryImplBase(const VirtualHostImpl& vhost,
                           route.hidden_envoy_deprecated_per_filter_config(), factory_context,
                           validator),
       route_name_(route.name()), time_source_(factory_context.dispatcher().timeSource()),
-      internal_redirect_action_(convertInternalRedirectAction(route.route())) {
+      internal_redirect_action_(convertInternalRedirectAction(route.route())),
+      max_internal_redirects_(
+          PROTOBUF_GET_WRAPPED_OR_DEFAULT(route.route(), max_internal_redirects, 1)) {
   if (route.route().has_metadata_match()) {
     const auto filter_it = route.route().metadata_match().filter_metadata().find(
         Envoy::Config::MetadataFilters::get().ENVOY_LB);

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -450,6 +450,7 @@ public:
   InternalRedirectAction internalRedirectAction() const override {
     return internal_redirect_action_;
   }
+  uint32_t maxInternalRedirects() const override { return max_internal_redirects_; }
 
   // Router::DirectResponseEntry
   std::string newPath(const Http::HeaderMap& headers) const override;
@@ -566,6 +567,7 @@ private:
     InternalRedirectAction internalRedirectAction() const override {
       return parent_->internalRedirectAction();
     }
+    uint32_t maxInternalRedirects() const override { return parent_->maxInternalRedirects(); }
 
     // Router::Route
     const DirectResponseEntry* directResponseEntry() const override { return nullptr; }
@@ -711,6 +713,7 @@ private:
   const std::string route_name_;
   TimeSource& time_source_;
   InternalRedirectAction internal_redirect_action_;
+  uint32_t max_internal_redirects_{1};
 };
 
 /**

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -32,6 +32,7 @@
 #include "common/router/debug_config.h"
 #include "common/router/retry_state_impl.h"
 #include "common/runtime/runtime_impl.h"
+#include "common/stream_info/uint32_accessor_impl.h"
 #include "common/tracing/http_tracer_impl.h"
 
 #include "extensions/filters/http/well_known_names.h"
@@ -39,6 +40,8 @@
 namespace Envoy {
 namespace Router {
 namespace {
+constexpr char NumInternalRedirectsFilterStateName[] = "num_internal_redirects";
+
 uint32_t getLength(const Buffer::Instance* instance) { return instance ? instance->length() : 0; }
 
 bool schemeIsHttp(const Http::HeaderMap& downstream_headers,
@@ -55,12 +58,10 @@ bool schemeIsHttp(const Http::HeaderMap& downstream_headers,
 }
 
 bool convertRequestHeadersForInternalRedirect(Http::HeaderMap& downstream_headers,
+                                              StreamInfo::FilterState& filter_state,
+                                              uint32_t max_internal_redirects,
                                               const Http::HeaderEntry& internal_redirect,
                                               const Network::Connection& connection) {
-  // Envoy does not currently support multiple rounds of redirects.
-  if (downstream_headers.EnvoyOriginalUrl()) {
-    return false;
-  }
   // Make sure the redirect response contains a URL to redirect to.
   if (internal_redirect.value().getStringView().length() == 0) {
     return false;
@@ -71,11 +72,27 @@ bool convertRequestHeadersForInternalRedirect(Http::HeaderMap& downstream_header
     return false;
   }
 
+  // Don't allow serving TLS responses over plaintext.
   bool scheme_is_http = schemeIsHttp(downstream_headers, connection);
   if (scheme_is_http && absolute_url.scheme() == Http::Headers::get().SchemeValues.Https) {
-    // Don't allow serving TLS responses over plaintext.
     return false;
   }
+
+  // Make sure that performing the redirect won't result in exceeding the configured number of
+  // redirects allowed for this route.
+  if (!filter_state.hasData<StreamInfo::UInt32Accessor>(NumInternalRedirectsFilterStateName)) {
+    filter_state.setData(NumInternalRedirectsFilterStateName,
+                         std::make_shared<StreamInfo::UInt32AccessorImpl>(0),
+                         StreamInfo::FilterState::StateType::Mutable,
+                         StreamInfo::FilterState::LifeSpan::DownstreamRequest);
+  }
+  StreamInfo::UInt32Accessor& num_internal_redirect =
+      filter_state.getDataMutable<StreamInfo::UInt32Accessor>(NumInternalRedirectsFilterStateName);
+
+  if (num_internal_redirect.value() >= max_internal_redirects) {
+    return false;
+  }
+  num_internal_redirect.increment();
 
   // Preserve the original request URL for the second pass.
   downstream_headers.setEnvoyOriginalUrl(
@@ -1359,11 +1376,14 @@ bool Filter::setupRedirect(const Http::HeaderMap& headers, UpstreamRequest& upst
   attempting_internal_redirect_with_complete_stream_ =
       upstream_request.upstream_timing_.last_upstream_rx_byte_received_ && downstream_end_stream_;
 
+  StreamInfo::FilterState& filter_state = callbacks_->streamInfo().filterState();
+
   // As with setupRetry, redirects are not supported for streaming requests yet.
   if (downstream_end_stream_ &&
       !callbacks_->decodingBuffer() && // Redirects with body not yet supported.
       location != nullptr &&
-      convertRequestHeadersForInternalRedirect(*downstream_headers_, *location,
+      convertRequestHeadersForInternalRedirect(*downstream_headers_, filter_state,
+                                               route_entry_->maxInternalRedirects(), *location,
                                                *callbacks_->connection()) &&
       callbacks_->recreateStream()) {
     cluster_->stats().upstream_internal_redirect_succeeded_total_.inc();

--- a/source/common/stream_info/BUILD
+++ b/source/common/stream_info/BUILD
@@ -39,3 +39,11 @@ envoy_cc_library(
         "//include/envoy/stream_info:stream_info_interface",
     ],
 )
+
+envoy_cc_library(
+    name = "uint32_accessor_lib",
+    hdrs = ["uint32_accessor_impl.h"],
+    deps = [
+        "//include/envoy/stream_info:uint32_accessor_interface",
+    ],
+)

--- a/source/common/stream_info/uint32_accessor_impl.h
+++ b/source/common/stream_info/uint32_accessor_impl.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "envoy/stream_info/uint32_accessor.h"
+
+namespace Envoy {
+namespace StreamInfo {
+
+/*
+ * A FilterState object that tracks a single uint32_t value.
+ */
+class UInt32AccessorImpl : public UInt32Accessor {
+public:
+  UInt32AccessorImpl(uint32_t value) : value_(value) {}
+
+  // From FilterState::Object
+  ProtobufTypes::MessagePtr serializeAsProto() const override {
+    auto message = std::make_unique<ProtobufWkt::UInt32Value>();
+    message->set_value(value_);
+    return message;
+  }
+
+  // From UInt32Accessor.
+  void increment() override { value_++; }
+  uint32_t value() const override { return value_; }
+
+private:
+  uint32_t value_;
+};
+
+} // namespace StreamInfo
+} // namespace Envoy

--- a/test/common/router/BUILD
+++ b/test/common/router/BUILD
@@ -252,6 +252,7 @@ envoy_cc_test(
         "//source/common/network:application_protocol_lib",
         "//source/common/network:utility_lib",
         "//source/common/router:router_lib",
+        "//source/common/stream_info:uint32_accessor_lib",
         "//source/common/upstream:upstream_includes",
         "//source/common/upstream:upstream_lib",
         "//test/common/http:common_lib",

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -2411,6 +2411,7 @@ virtual_hosts:
     route->routeEntry()->grpcTimeoutOffset();
     route->routeEntry()->upgradeMap();
     route->routeEntry()->internalRedirectAction();
+    route->routeEntry()->maxInternalRedirects();
   }
 }
 

--- a/test/common/stream_info/BUILD
+++ b/test/common/stream_info/BUILD
@@ -59,3 +59,11 @@ envoy_cc_test(
         "//test/mocks/stream_info:stream_info_mocks",
     ],
 )
+
+envoy_cc_test(
+    name = "uint32_accessor_impl_test",
+    srcs = ["uint32_accessor_impl_test.cc"],
+    deps = [
+        "//source/common/stream_info:uint32_accessor_lib",
+    ],
+)

--- a/test/common/stream_info/uint32_accessor_impl_test.cc
+++ b/test/common/stream_info/uint32_accessor_impl_test.cc
@@ -1,0 +1,24 @@
+#include "common/stream_info/uint32_accessor_impl.h"
+
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace StreamInfo {
+namespace {
+
+TEST(UInt32AccessorImplTest, ConstructorInitsValue) {
+  uint32_t init_value = 0xdeadbeef;
+  UInt32AccessorImpl accessor(init_value);
+  EXPECT_EQ(init_value, accessor.value());
+}
+
+TEST(UInt32AccessorImplTest, IncrementValue) {
+  uint32_t init_value = 0xdeadbeef;
+  UInt32AccessorImpl accessor(init_value);
+  accessor.increment();
+  EXPECT_EQ(0xdeadbef0, accessor.value());
+}
+
+} // namespace
+} // namespace StreamInfo
+} // namespace Envoy

--- a/test/integration/redirect_integration_test.cc
+++ b/test/integration/redirect_integration_test.cc
@@ -5,6 +5,11 @@
 
 namespace Envoy {
 
+namespace {
+constexpr char HandleThreeHopLocationFormat[] =
+    "http://handle.internal.redirect.max.three.hop/path{}";
+}
+
 class RedirectIntegrationTest : public HttpProtocolIntegrationTest {
 public:
   void initialize() override {
@@ -18,12 +23,62 @@ public:
         envoy::config::route::v3alpha::RouteAction::HANDLE_INTERNAL_REDIRECT);
     config_helper_.addVirtualHost(handle);
 
+    auto handle_max_3_hop =
+        config_helper_.createVirtualHost("handle.internal.redirect.max.three.hop");
+    handle_max_3_hop.mutable_routes(0)->mutable_route()->set_internal_redirect_action(
+        envoy::config::route::v3alpha::RouteAction::HANDLE_INTERNAL_REDIRECT);
+    handle_max_3_hop.mutable_routes(0)
+        ->mutable_route()
+        ->mutable_max_internal_redirects()
+        ->set_value(3);
+    config_helper_.addVirtualHost(handle_max_3_hop);
+
     HttpProtocolIntegrationTest::initialize();
   }
 
 protected:
+  // Returns the next stream that the fake upstream receives.
+  FakeStreamPtr waitForNextStream() {
+    FakeStreamPtr new_stream = nullptr;
+    auto wait_new_stream_fn = [this,
+                               &new_stream](FakeHttpConnectionPtr& connection) -> AssertionResult {
+      AssertionResult result = connection->waitForNewStream(*dispatcher_, new_stream, false,
+                                                            std::chrono::milliseconds(50));
+      if (result) {
+        ASSERT(new_stream);
+      }
+      return result;
+    };
+
+    // Using a while loop to poll for new connections and new streams on all
+    // connections because connection reuse may or may not be triggered.
+    while (new_stream == nullptr) {
+      FakeHttpConnectionPtr new_connection = nullptr;
+
+      AssertionResult result = fake_upstreams_[0]->waitForHttpConnection(
+          *dispatcher_, new_connection, std::chrono::milliseconds(50), 60, 100);
+      if (result) {
+        ASSERT(new_connection);
+        upstream_connections_.push_back(std::move(new_connection));
+      }
+
+      for (auto& connection : upstream_connections_) {
+        result = wait_new_stream_fn(connection);
+        if (result) {
+          break;
+        }
+      }
+    }
+
+    AssertionResult result = new_stream->waitForEndStream(*dispatcher_);
+    ASSERT(result);
+    return new_stream;
+  }
+
   Http::TestHeaderMapImpl redirect_response_{
       {":status", "302"}, {"content-length", "0"}, {"location", "http://authority2/new/url"}};
+
+  std::vector<FakeHttpConnectionPtr> upstream_connections_;
 };
 
 // By default if internal redirects are not configured, redirects are proxied.
@@ -82,6 +137,45 @@ TEST_P(RedirectIntegrationTest, BasicInternalRedirect) {
   EXPECT_EQ("200", response->headers().Status()->value().getStringView());
   EXPECT_EQ(1, test_server_->counter("cluster.cluster_0.upstream_internal_redirect_succeeded_total")
                    ->value());
+}
+
+TEST_P(RedirectIntegrationTest, InternalRedirectWithThreeHopLimit) {
+  // Validate that header sanitization is only called once.
+  config_helper_.addConfigModifier(
+      [](envoy::extensions::filters::network::http_connection_manager::v3alpha::
+             HttpConnectionManager& hcm) { hcm.set_via("via_value"); });
+  initialize();
+  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  default_request_headers_.setHost("handle.internal.redirect.max.three.hop");
+  default_request_headers_.setPath("/path0");
+  IntegrationStreamDecoderPtr response =
+      codec_client_->makeHeaderOnlyRequest(default_request_headers_);
+
+  std::vector<FakeStreamPtr> upstream_requests;
+  // Four requests to upstream: 1 original request + 3 following redirect
+  for (int i = 0; i < 4; i++) {
+    upstream_requests.push_back(waitForNextStream());
+
+    EXPECT_EQ(fmt::format("/path{}", i),
+              upstream_requests.back()->headers().Path()->value().getStringView());
+    EXPECT_EQ("handle.internal.redirect.max.three.hop",
+              upstream_requests.back()->headers().Host()->value().getStringView());
+    EXPECT_EQ("via_value", upstream_requests.back()->headers().Via()->value().getStringView());
+
+    auto next_location = fmt::format(HandleThreeHopLocationFormat, i + 1);
+    redirect_response_.setLocation(next_location);
+    upstream_requests.back()->encodeHeaders(redirect_response_, true);
+  }
+
+  response->waitForEndStream();
+  ASSERT_TRUE(response->complete());
+  EXPECT_EQ("302", response->headers().Status()->value().getStringView());
+  EXPECT_EQ(
+      1,
+      test_server_->counter("cluster.cluster_0.upstream_internal_redirect_failed_total")->value());
 }
 
 TEST_P(RedirectIntegrationTest, InternalRedirectToDestinationWithBody) {

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -343,6 +343,7 @@ public:
   MOCK_CONST_METHOD0(includeAttemptCount, bool());
   MOCK_CONST_METHOD0(upgradeMap, const UpgradeMap&());
   MOCK_CONST_METHOD0(internalRedirectAction, InternalRedirectAction());
+  MOCK_CONST_METHOD0(maxInternalRedirects, uint32_t());
   MOCK_CONST_METHOD0(routeName, const std::string&());
 
   std::string cluster_name_{"fake_cluster"};


### PR DESCRIPTION
…rnal redirect hops (#9574)

Add support for per-route configurable maximum number of internal redirect hops

Risk Level: Medium
Testing: Unit and integration tests added / modified
Docs Changes: Described the new field in intro/arch_overview/http/http_connection_management.rst
Release Notes: Added

Fixes #9144

Signed-off-by: Peng Gao <pengg@google.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
