### PR TITLE
api: add 'redacted' option for protobuf messages, and redact SSL cert…

### DIFF
--- a/api/envoy/api/v2/auth/cert.proto
+++ b/api/envoy/api/v2/auth/cert.proto
@@ -11,6 +11,8 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
+import "udpa/annotations/sensitive.proto";
+
 import "udpa/annotations/migrate.proto";
 import "validate/validate.proto";
 
@@ -128,7 +130,7 @@ message TlsCertificate {
   core.DataSource certificate_chain = 1;
 
   // The TLS private key.
-  core.DataSource private_key = 2;
+  core.DataSource private_key = 2 [(udpa.annotations.sensitive) = true];
 
   // BoringSSL private key method provider. This is an alternative to :ref:`private_key
   // <envoy_api_field_auth.TlsCertificate.private_key>` field. This can't be
@@ -141,7 +143,7 @@ message TlsCertificate {
 
   // The password to decrypt the TLS private key. If this field is not set, it is assumed that the
   // TLS private key is not password encrypted.
-  core.DataSource password = 3;
+  core.DataSource password = 3 [(udpa.annotations.sensitive) = true];
 
   // [#not-implemented-hide:]
   core.DataSource ocsp_staple = 4;
@@ -174,7 +176,8 @@ message TlsSessionTicketKeys {
   //   * Keep the session ticket keys at least as secure as your TLS certificate private keys
   //   * Rotate session ticket keys at least daily, and preferably hourly
   //   * Always generate keys using a cryptographically-secure random data source
-  repeated core.DataSource keys = 1 [(validate.rules).repeated = {min_items: 1}];
+  repeated core.DataSource keys = 1
+      [(validate.rules).repeated = {min_items: 1}, (udpa.annotations.sensitive) = true];
 }
 
 // [#next-free-field: 10]

--- a/api/envoy/extensions/transport_sockets/tls/v3alpha/cert.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v3alpha/cert.proto
@@ -11,6 +11,7 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
+import "udpa/annotations/sensitive.proto";
 import "udpa/annotations/versioning.proto";
 
 import "validate/validate.proto";
@@ -136,7 +137,7 @@ message TlsCertificate {
   config.core.v3alpha.DataSource certificate_chain = 1;
 
   // The TLS private key.
-  config.core.v3alpha.DataSource private_key = 2;
+  config.core.v3alpha.DataSource private_key = 2 [(udpa.annotations.sensitive) = true];
 
   // BoringSSL private key method provider. This is an alternative to :ref:`private_key
   // <envoy_api_field_extensions.transport_sockets.tls.v3alpha.TlsCertificate.private_key>` field.
@@ -150,7 +151,7 @@ message TlsCertificate {
 
   // The password to decrypt the TLS private key. If this field is not set, it is assumed that the
   // TLS private key is not password encrypted.
-  config.core.v3alpha.DataSource password = 3;
+  config.core.v3alpha.DataSource password = 3 [(udpa.annotations.sensitive) = true];
 
   // [#not-implemented-hide:]
   config.core.v3alpha.DataSource ocsp_staple = 4;
@@ -187,7 +188,8 @@ message TlsSessionTicketKeys {
   //   * Keep the session ticket keys at least as secure as your TLS certificate private keys
   //   * Rotate session ticket keys at least daily, and preferably hourly
   //   * Always generate keys using a cryptographically-secure random data source
-  repeated config.core.v3alpha.DataSource keys = 1 [(validate.rules).repeated = {min_items: 1}];
+  repeated config.core.v3alpha.DataSource keys = 1
+      [(validate.rules).repeated = {min_items: 1}, (udpa.annotations.sensitive) = true];
 }
 
 // [#next-free-field: 10]

--- a/docs/root/operations/admin.rst
+++ b/docs/root/operations/admin.rst
@@ -126,6 +126,14 @@ modify different aspects of the server:
   information.
 
 .. warning::
+  Configuration may include :ref:`TLS certificates <envoy_api_msg_auth.TlsCertificate>`. Before
+  dumping the configuration, Envoy will attempt to redact the ``private_key`` and ``password``
+  fields from any certificates it finds. This relies on the configuration being a strongly-typed
+  protobuf message. If your Envoy configuration uses deprecated ``config`` fields (of type
+  ``google.protobuf.Struct``), please update to the recommended ``typed_config`` fields (of type
+  ``google.protobuf.Any``) to ensure sensitive data is redacted properly.
+
+.. warning::
   The underlying proto is marked v2alpha and hence its contents, including the JSON representation,
   are not guaranteed to be stable.
 

--- a/generated_api_shadow/envoy/api/v2/auth/cert.proto
+++ b/generated_api_shadow/envoy/api/v2/auth/cert.proto
@@ -11,6 +11,8 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
+import "udpa/annotations/sensitive.proto";
+
 import "udpa/annotations/migrate.proto";
 import "validate/validate.proto";
 
@@ -128,7 +130,7 @@ message TlsCertificate {
   core.DataSource certificate_chain = 1;
 
   // The TLS private key.
-  core.DataSource private_key = 2;
+  core.DataSource private_key = 2 [(udpa.annotations.sensitive) = true];
 
   // BoringSSL private key method provider. This is an alternative to :ref:`private_key
   // <envoy_api_field_auth.TlsCertificate.private_key>` field. This can't be
@@ -141,7 +143,7 @@ message TlsCertificate {
 
   // The password to decrypt the TLS private key. If this field is not set, it is assumed that the
   // TLS private key is not password encrypted.
-  core.DataSource password = 3;
+  core.DataSource password = 3 [(udpa.annotations.sensitive) = true];
 
   // [#not-implemented-hide:]
   core.DataSource ocsp_staple = 4;
@@ -174,7 +176,8 @@ message TlsSessionTicketKeys {
   //   * Keep the session ticket keys at least as secure as your TLS certificate private keys
   //   * Rotate session ticket keys at least daily, and preferably hourly
   //   * Always generate keys using a cryptographically-secure random data source
-  repeated core.DataSource keys = 1 [(validate.rules).repeated = {min_items: 1}];
+  repeated core.DataSource keys = 1
+      [(validate.rules).repeated = {min_items: 1}, (udpa.annotations.sensitive) = true];
 }
 
 // [#next-free-field: 10]

--- a/generated_api_shadow/envoy/extensions/transport_sockets/tls/v3alpha/cert.proto
+++ b/generated_api_shadow/envoy/extensions/transport_sockets/tls/v3alpha/cert.proto
@@ -11,6 +11,7 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
+import "udpa/annotations/sensitive.proto";
 import "udpa/annotations/versioning.proto";
 
 import "validate/validate.proto";
@@ -134,7 +135,7 @@ message TlsCertificate {
   config.core.v3alpha.DataSource certificate_chain = 1;
 
   // The TLS private key.
-  config.core.v3alpha.DataSource private_key = 2;
+  config.core.v3alpha.DataSource private_key = 2 [(udpa.annotations.sensitive) = true];
 
   // BoringSSL private key method provider. This is an alternative to :ref:`private_key
   // <envoy_api_field_extensions.transport_sockets.tls.v3alpha.TlsCertificate.private_key>` field.
@@ -148,7 +149,7 @@ message TlsCertificate {
 
   // The password to decrypt the TLS private key. If this field is not set, it is assumed that the
   // TLS private key is not password encrypted.
-  config.core.v3alpha.DataSource password = 3;
+  config.core.v3alpha.DataSource password = 3 [(udpa.annotations.sensitive) = true];
 
   // [#not-implemented-hide:]
   config.core.v3alpha.DataSource ocsp_staple = 4;
@@ -185,7 +186,8 @@ message TlsSessionTicketKeys {
   //   * Keep the session ticket keys at least as secure as your TLS certificate private keys
   //   * Rotate session ticket keys at least daily, and preferably hourly
   //   * Always generate keys using a cryptographically-secure random data source
-  repeated config.core.v3alpha.DataSource keys = 1 [(validate.rules).repeated = {min_items: 1}];
+  repeated config.core.v3alpha.DataSource keys = 1
+      [(validate.rules).repeated = {min_items: 1}, (udpa.annotations.sensitive) = true];
 }
 
 // [#next-free-field: 10]

--- a/source/common/protobuf/BUILD
+++ b/source/common/protobuf/BUILD
@@ -68,6 +68,7 @@ envoy_cc_library(
         "//source/common/common:utility_lib",
         "//source/common/config:api_type_oracle_lib",
         "//source/common/config:version_converter_lib",
+        "@com_github_cncf_udpa//udpa/annotations:pkg_cc_proto",
         "@envoy_api//envoy/annotations:pkg_cc_proto",
         "@envoy_api//envoy/type/v3alpha:pkg_cc_proto",
     ],

--- a/source/common/protobuf/utility.h
+++ b/source/common/protobuf/utility.h
@@ -363,6 +363,27 @@ public:
    * @param code the protobuf error code
    */
   static std::string CodeEnumToString(ProtobufUtil::error::Code code);
+
+  /**
+   * Modifies a message such that all sensitive data (that is, fields annotated as
+   * `udpa.annotations.sensitive`) is redacted for display. String-typed fields annotated as
+   * `sensitive` will be replaced with the string "[redacted]", bytes-typed fields will be replaced
+   * with the bytes `5B72656461637465645D` (the ASCII / UTF-8 encoding of the string "[redacted]"),
+   * primitive-typed fields (including enums) will be cleared, and message-typed fields will be
+   * traversed recursively to redact their contents.
+   *
+   * LIMITATION: This works properly for strongly-typed messages, as well as for messages packed in
+   * a `ProtobufWkt::Any` with a `type_url` corresponding to a proto that was compiled into the
+   * Envoy binary. However it does not work for messages encoded as `ProtobufWkt::Struct`, since
+   * structs are missing the "sensitive" annotations that this function expects. Similarly, it fails
+   * for messages encoded as `ProtobufWkt::Any` with a `type_url` that isn't registered with the
+   * binary. If you're working with struct-typed messages, including those that might be hiding
+   * within strongly-typed messages, please reify them to strongly-typed messages using
+   * `MessageUtil::jsonConvert()` before calling `MessageUtil::redact()`.
+   *
+   * @param message message to redact.
+   */
+  static void redact(Protobuf::Message& message);
 };
 
 class ValueUtil {

--- a/source/common/secret/BUILD
+++ b/source/common/secret/BUILD
@@ -20,6 +20,7 @@ envoy_cc_library(
         "//source/common/common:assert_lib",
         "//source/common/common:minimal_logger_lib",
         "//source/common/config:version_converter_lib",
+        "//source/common/protobuf:utility_lib",
         "@envoy_api//envoy/admin/v3alpha:pkg_cc_proto",
         "@envoy_api//envoy/config/core/v3alpha:pkg_cc_proto",
         "@envoy_api//envoy/extensions/transport_sockets/tls/v3alpha:pkg_cc_proto",

--- a/source/common/secret/secret_manager_impl.cc
+++ b/source/common/secret/secret_manager_impl.cc
@@ -9,6 +9,7 @@
 #include "common/common/assert.h"
 #include "common/common/logger.h"
 #include "common/config/version_converter.h"
+#include "common/protobuf/utility.h"
 #include "common/secret/sds_api.h"
 #include "common/secret/secret_provider_impl.h"
 #include "common/ssl/certificate_validation_context_config_impl.h"
@@ -125,36 +126,6 @@ SecretManagerImpl::findOrCreateTlsSessionTicketKeysContextProvider(
                                                      secret_provider_context);
 }
 
-// We clear private key, password, and session ticket encryption keys to avoid information leaking.
-// TODO(incfly): switch to more generic scrubbing mechanism once
-// https://github.com/envoyproxy/envoy/issues/4757 is resolved.
-void redactSecret(envoy::extensions::transport_sockets::tls::v3alpha::Secret* secret) {
-  if (secret &&
-      secret->type_case() ==
-          envoy::extensions::transport_sockets::tls::v3alpha::Secret::TypeCase::kTlsCertificate) {
-    auto tls_certificate = secret->mutable_tls_certificate();
-    if (tls_certificate->has_private_key() &&
-        tls_certificate->private_key().specifier_case() !=
-            envoy::config::core::v3alpha::DataSource::SpecifierCase::kFilename) {
-      tls_certificate->mutable_private_key()->set_inline_string("[redacted]");
-    }
-    if (tls_certificate->has_password() &&
-        tls_certificate->password().specifier_case() !=
-            envoy::config::core::v3alpha::DataSource::SpecifierCase::kFilename) {
-      tls_certificate->mutable_password()->set_inline_string("[redacted]");
-    }
-  }
-  if (secret && secret->type_case() == envoy::extensions::transport_sockets::tls::v3alpha::Secret::
-                                           TypeCase::kSessionTicketKeys) {
-    for (auto& data_source : *secret->mutable_session_ticket_keys()->mutable_keys()) {
-      if (data_source.specifier_case() !=
-          envoy::config::core::v3alpha::DataSource::SpecifierCase::kFilename) {
-        data_source.set_inline_string("[redacted]");
-      }
-    }
-  }
-}
-
 ProtobufTypes::MessagePtr SecretManagerImpl::dumpSecretConfigs() {
   // TODO(htuch): unlike other config providers, we're recreating the original
   // Secrets below. This makes it hard to support API_RECOVER_ORIGINAL()-style
@@ -171,7 +142,7 @@ ProtobufTypes::MessagePtr SecretManagerImpl::dumpSecretConfigs() {
     envoy::extensions::transport_sockets::tls::v3alpha::Secret dump_secret;
     dump_secret.set_name(cert_iter.first);
     dump_secret.mutable_tls_certificate()->MergeFrom(*tls_cert->secret());
-    redactSecret(&dump_secret);
+    MessageUtil::redact(dump_secret);
     static_secret->mutable_secret()->PackFrom(dump_secret);
   }
 
@@ -198,7 +169,7 @@ ProtobufTypes::MessagePtr SecretManagerImpl::dumpSecretConfigs() {
     for (const auto& key : session_ticket_keys->secret()->keys()) {
       dump_secret.mutable_session_ticket_keys()->add_keys()->MergeFrom(key);
     }
-    redactSecret(&dump_secret);
+    MessageUtil::redact(dump_secret);
     static_secret->mutable_secret()->PackFrom(dump_secret);
   }
 
@@ -225,7 +196,7 @@ ProtobufTypes::MessagePtr SecretManagerImpl::dumpSecretConfigs() {
     if (secret_ready) {
       secret.mutable_tls_certificate()->MergeFrom(*tls_cert);
     }
-    redactSecret(&secret);
+    MessageUtil::redact(secret);
     dump_secret->mutable_secret()->PackFrom(secret);
   }
 
@@ -276,7 +247,7 @@ ProtobufTypes::MessagePtr SecretManagerImpl::dumpSecretConfigs() {
     if (secret_ready) {
       secret.mutable_session_ticket_keys()->MergeFrom(*tls_stek);
     }
-    redactSecret(&secret);
+    MessageUtil::redact(secret);
     dump_secret->mutable_secret()->PackFrom(secret);
   }
   return config_dump;

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -698,6 +698,7 @@ Http::Code AdminImpl::handlerConfigDump(absl::string_view url, Http::HeaderMap& 
   } else {
     addAllConfigToDump(dump, mask);
   }
+  MessageUtil::redact(dump);
 
   response_headers.setReferenceContentType(Http::Headers::get().ContentTypeValues.Json);
   response.add(MessageUtil::getJsonStringFromMessage(dump, true)); // pretty-print

--- a/test/common/protobuf/BUILD
+++ b/test/common/protobuf/BUILD
@@ -31,6 +31,7 @@ envoy_cc_test(
         "//test/mocks/protobuf:protobuf_mocks",
         "//test/mocks/server:server_mocks",
         "//test/proto:deprecated_proto_cc_proto",
+        "//test/proto:sensitive_proto_cc_proto",
         "//test/test_common:environment_lib",
         "//test/test_common:logging_lib",
         "//test/test_common:utility_lib",

--- a/test/common/secret/secret_manager_impl_test.cc
+++ b/test/common/secret/secret_manager_impl_test.cc
@@ -515,9 +515,9 @@ dynamic_active_secrets:
     name: "abc.com.stek"
     session_ticket_keys:
       keys:
-        - filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/ticket_key_a"
+        - filename: "[redacted]"
         - inline_string: "[redacted]"
-        - inline_string: "[redacted]"
+        - inline_bytes: "W3JlZGFjdGVkXQ=="
 )EOF";
   checkConfigDump(TestEnvironment::substitute(updated_once_more_config_dump));
 }
@@ -691,58 +691,6 @@ static_secrets:
   checkConfigDump(expected_config_dump);
 }
 
-TEST_F(SecretManagerImplTest, ConfigDumpNotRedactFilenamePrivateKey) {
-  Server::MockInstance server;
-  auto secret_manager = std::make_unique<SecretManagerImpl>(config_tracker_);
-  time_system_.setSystemTime(std::chrono::milliseconds(1234567891234));
-  NiceMock<Server::Configuration::MockTransportSocketFactoryContext> secret_context;
-  envoy::config::core::v3alpha::ConfigSource config_source;
-  NiceMock<LocalInfo::MockLocalInfo> local_info;
-  NiceMock<Event::MockDispatcher> dispatcher;
-  NiceMock<Runtime::MockRandomGenerator> random;
-  Stats::IsolatedStoreImpl stats;
-  NiceMock<Init::MockManager> init_manager;
-  NiceMock<Init::ExpectableWatcherImpl> init_watcher;
-  Init::TargetHandlePtr init_target_handle;
-  EXPECT_CALL(init_manager, add(_))
-      .WillRepeatedly(Invoke([&init_target_handle](const Init::Target& target) {
-        init_target_handle = target.createHandle("test");
-      }));
-  EXPECT_CALL(secret_context, stats()).WillRepeatedly(ReturnRef(stats));
-  EXPECT_CALL(secret_context, initManager()).WillRepeatedly(Return(&init_manager));
-  EXPECT_CALL(secret_context, dispatcher()).WillRepeatedly(ReturnRef(dispatcher));
-  EXPECT_CALL(secret_context, localInfo()).WillRepeatedly(ReturnRef(local_info));
-
-  const std::string tls_certificate = R"EOF(
-name: "abc.com"
-tls_certificate:
-  certificate_chain:
-    inline_string: "DUMMY_INLINE_BYTES_FOR_CERT_CHAIN"
-  private_key:
-    inline_string: "DUMMY_INLINE_BYTES_FOR_PRIVATE_KEY"
-  password:
-    filename: "/etc/certs/password"
-)EOF";
-  envoy::extensions::transport_sockets::tls::v3alpha::Secret tls_cert_secret;
-  TestUtility::loadFromYaml(TestEnvironment::substitute(tls_certificate), tls_cert_secret);
-  secret_manager->addStaticSecret(tls_cert_secret);
-  const std::string expected_config_dump = R"EOF(
-static_secrets:
-- name: "abc.com" 
-  secret:
-    "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3alpha.Secret
-    name: "abc.com"
-    tls_certificate:
-      certificate_chain:
-        inline_string: "DUMMY_INLINE_BYTES_FOR_CERT_CHAIN"
-      private_key:
-        inline_string: "[redacted]"
-      password:
-        filename: "/etc/certs/password"
-)EOF";
-  checkConfigDump(expected_config_dump);
-}
-
 TEST_F(SecretManagerImplTest, ConfigDumpHandlerStaticValidationContext) {
   Server::MockInstance server;
   auto secret_manager = std::make_unique<SecretManagerImpl>(config_tracker_);
@@ -830,9 +778,9 @@ static_secrets:
     name: "abc.com.stek"
     session_ticket_keys:
       keys:
-        - filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/ticket_key_a"
+        - filename: "[redacted]"
         - inline_string: "[redacted]"
-        - inline_string: "[redacted]"
+        - inline_bytes: "W3JlZGFjdGVkXQ=="
 )EOF";
   checkConfigDump(TestEnvironment::substitute(expected_config_dump));
 }

--- a/test/proto/BUILD
+++ b/test/proto/BUILD
@@ -43,3 +43,12 @@ envoy_proto_descriptor(
         "well_known_protos",
     ],
 )
+
+envoy_proto_library(
+    name = "sensitive_proto",
+    srcs = [":sensitive.proto"],
+    deps = [
+        "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/type/v1:pkg",
+    ],
+)

--- a/test/proto/sensitive.proto
+++ b/test/proto/sensitive.proto
@@ -1,0 +1,42 @@
+syntax = "proto3";
+
+package envoy.test;
+
+option java_package = "io.envoyproxy.envoy.test";
+option java_outer_classname = "SensitiveProto";
+option java_multiple_files = true;
+
+import "google/protobuf/any.proto";
+import "google/protobuf/struct.proto";
+
+import "udpa/annotations/sensitive.proto";
+import "udpa/type/v1/typed_struct.proto";
+
+message Sensitive {
+  string sensitive_string = 1 [(udpa.annotations.sensitive) = true];
+  repeated string sensitive_repeated_string = 2 [(udpa.annotations.sensitive) = true];
+  bytes sensitive_bytes = 3 [(udpa.annotations.sensitive) = true];
+  repeated bytes sensitive_repeated_bytes = 4 [(udpa.annotations.sensitive) = true];
+  int64 sensitive_int = 5 [(udpa.annotations.sensitive) = true];
+  repeated int64 sensitive_repeated_int = 6 [(udpa.annotations.sensitive) = true];
+  Sensitive sensitive_message = 7 [(udpa.annotations.sensitive) = true];
+  repeated Sensitive sensitive_repeated_message = 8 [(udpa.annotations.sensitive) = true];
+  google.protobuf.Any sensitive_any = 9 [(udpa.annotations.sensitive) = true];
+  repeated google.protobuf.Any sensitive_repeated_any = 10 [(udpa.annotations.sensitive) = true];
+  udpa.type.v1.TypedStruct sensitive_typed_struct = 11 [(udpa.annotations.sensitive) = true];
+  repeated udpa.type.v1.TypedStruct sensitive_repeated_typed_struct = 12
+      [(udpa.annotations.sensitive) = true];
+
+  string insensitive_string = 101;
+  repeated string insensitive_repeated_string = 102;
+  bytes insensitive_bytes = 103;
+  repeated bytes insensitive_repeated_bytes = 104;
+  int64 insensitive_int = 105;
+  repeated int64 insensitive_repeated_int = 106;
+  Sensitive insensitive_message = 107;
+  repeated Sensitive insensitive_repeated_message = 108;
+  google.protobuf.Any insensitive_any = 109;
+  repeated google.protobuf.Any insensitive_repeated_any = 110;
+  udpa.type.v1.TypedStruct insensitive_typed_struct = 111;
+  repeated udpa.type.v1.TypedStruct insensitive_repeated_typed_struct = 112;
+}

--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -46,6 +46,7 @@ REAL_TIME_WHITELIST = ("./source/common/common/utility.h",
 # Files in these paths can use MessageLite::SerializeAsString
 SERIALIZE_AS_STRING_WHITELIST = (
     "./source/common/config/version_converter.cc",
+    "./source/common/protobuf/utility.cc",
     "./source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc",
     "./test/common/protobuf/utility_test.cc",
     "./test/common/config/version_converter_test.cc",

--- a/tools/protoxform/protoxform.py
+++ b/tools/protoxform/protoxform.py
@@ -32,6 +32,7 @@ from google.protobuf import text_format
 # Note: we have to include those proto definitions to make FormatOptions work,
 # this also serves as whitelist of extended options.
 from google.api import annotations_pb2 as _
+from udpa.annotations import sensitive_pb2 as _
 from validate import validate_pb2 as _
 from envoy.annotations import deprecation_pb2 as _
 from envoy.annotations import resource_pb2

--- a/tools/spelling_dictionary.txt
+++ b/tools/spelling_dictionary.txt
@@ -510,6 +510,7 @@ dir
 dirname
 djb
 downcasted
+downcasting
 downstreams
 dtor
 dubbo
@@ -882,6 +883,8 @@ referer
 refetch
 regex
 regexes
+reified
+reify
 reimplements
 rele
 releasor
@@ -893,6 +896,7 @@ repicked
 repo
 requirepass
 reselecting
+reserialize
 reservable
 resize
 resized


### PR DESCRIPTION
…s (#9315)

Implement MessageUtil::redact() to redact proto fields with the udpa.annotations.sensitive option set. Apply this to SSL certs in the admin config_dump.

Risk Level: low
Testing: unit tests

Signed-off-by: Dan Rosen <mergeconflict@google.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
