### PR TITLE
Allow per_try_timeout when global route timeout is disabled. (#10082)

### DIFF
--- a/docs/root/configuration/http/http_filters/router_filter.rst
+++ b/docs/root/configuration/http/http_filters/router_filter.rst
@@ -239,11 +239,11 @@ x-envoy-upstream-rq-per-try-timeout-ms
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Setting this header on egress requests will cause Envoy to set a *per try* timeout on routed
-requests. This timeout must be <= the global route timeout (see
-:ref:`config_http_filters_router_x-envoy-upstream-rq-timeout-ms`) or it is ignored. This allows a
-caller to set a tight per try timeout to allow for retries while maintaining a reasonable overall
-timeout. This timeout only applies before any part of the response is sent to the downstream,
-which normally happens after the upstream has sent response headers.
+requests. If a global route timeout is configured, this timeout must be less than the global route
+timeout (see :ref:`config_http_filters_router_x-envoy-upstream-rq-timeout-ms`) or it is ignored.
+This allows a caller to set a tight per try timeout to allow for retries while maintaining a
+reasonable overall timeout. This timeout only applies before any part of the response is sent to
+the downstream, which normally happens after the upstream has sent response headers.
 
 x-envoy-hedge-on-per-try-timeout
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/root/faq/configuration/timeouts.rst
+++ b/docs/root/faq/configuration/timeouts.rst
@@ -77,6 +77,8 @@ stream timeouts already introduced above.
   configured when using retries so that individual tries using a shorter timeout than the overall
   request timeout described above. This timeout only applies before any part of the response
   is sent to the downstream, which normally happens after the upstream has sent response headers.
+  This timeout can be used with streaming endpoints to retry if the upstream fails to begin a
+  response within the timeout.
 
 TCP
 ---

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -16,6 +16,7 @@ Version history
 * router: added :ref:`auto_san_validation <envoy_api_field_core.UpstreamHttpProtocolOptions.auto_san_validation>` to support overrriding SAN validation to transport socket for new upstream connections based on the downstream HTTP host/authority header.
 * router: added the ability to match a route based on whether a downstream TLS connection certificate has been
   :ref:`validated <envoy_api_field_route.RouteMatch.TlsContextMatchOptions.validated>`.
+* router: don't ignore :ref:`per_try_timeout <envoy_api_field_route.RetryPolicy.per_try_timeout>` when the :ref:`global route timeout <envoy_api_field_route.RouteAction.timeout>` is disabled.
 * sds: added :ref:`GenericSecret <envoy_api_msg_auth.GenericSecret>` to support secret of generic type.
 * stat sinks: stat sink extensions use the "envoy.stat_sinks" name space. A mapping of extension
   names is available in the :ref:`deprecated <deprecated>` documentation.

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -224,7 +224,7 @@ FilterUtility::finalTimeout(const RouteEntry& route, Http::HeaderMap& request_he
     request_headers.removeEnvoyUpstreamRequestPerTryTimeoutMs();
   }
 
-  if (timeout.per_try_timeout_ >= timeout.global_timeout_) {
+  if (timeout.per_try_timeout_ >= timeout.global_timeout_ && timeout.global_timeout_.count() != 0) {
     timeout.per_try_timeout_ = std::chrono::milliseconds(0);
   }
 


### PR DESCRIPTION
This allows, for instance, a per_try_timeout (which is only in
effect until the response to downstream begins) with streaming endpoints,
for which an overall timeout doesn't make sense.

Signed-off-by: Greg Greenway <ggreenway@apple.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
