### PR TITLE
docker: push SHA tag for release branch too (#10214)

### DIFF
--- a/ci/docker_build.sh
+++ b/ci/docker_build.sh
@@ -4,6 +4,6 @@ set -ex
 
 DOCKER_IMAGE_PREFIX="${DOCKER_IMAGE_PREFIX:-envoyproxy/envoy}"
 
-docker build -f ci/Dockerfile-envoy-image -t "${DOCKER_IMAGE_PREFIX}-dev:latest" .
-docker build -f ci/Dockerfile-envoy-alpine -t "${DOCKER_IMAGE_PREFIX}-alpine-dev:latest" .
-docker build -f ci/Dockerfile-envoy-alpine-debug -t "${DOCKER_IMAGE_PREFIX}-alpine-debug-dev:latest" .
+docker build -f ci/Dockerfile-envoy-image -t "${DOCKER_IMAGE_PREFIX}-dev:${CIRCLE_SHA1}" .
+docker build -f ci/Dockerfile-envoy-alpine -t "${DOCKER_IMAGE_PREFIX}-alpine-dev:${CIRCLE_SHA1}" .
+docker build -f ci/Dockerfile-envoy-alpine-debug -t "${DOCKER_IMAGE_PREFIX}-alpine-debug-dev:${CIRCLE_SHA1}" .

--- a/ci/docker_push.sh
+++ b/ci/docker_push.sh
@@ -12,13 +12,15 @@ fi
 DOCKER_IMAGE_PREFIX="${DOCKER_IMAGE_PREFIX:-envoyproxy/envoy}"
 
 # push the envoy image on tags or merge to master
-if [[ -n "$CIRCLE_TAG" ]] || [[ "$AZP_BRANCH" = 'refs/heads/master' ]]; then
+if [[ "${AZP_BRANCH}" == 'refs/heads/master' ]] || [[ "${AZP_BRACH}" =~ ^refs/heads/release/v.* ]]; then
     docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
 
     for BUILD_TYPE in "" "-alpine" "-alpine-debug"; do
-        docker push "${DOCKER_IMAGE_PREFIX}${BUILD_TYPE}-dev:latest"
-        docker tag "${DOCKER_IMAGE_PREFIX}${BUILD_TYPE}-dev:latest" "${DOCKER_IMAGE_PREFIX}${BUILD_TYPE}-dev:${CIRCLE_SHA1}"
         docker push "${DOCKER_IMAGE_PREFIX}${BUILD_TYPE}-dev:${CIRCLE_SHA1}"
+        if [[ "$AZP_BRANCH" == 'refs/heads/master' ]]; then
+            docker tag "${DOCKER_IMAGE_PREFIX}${BUILD_TYPE}-dev:${CIRCLE_SHA1}" "${DOCKER_IMAGE_PREFIX}${BUILD_TYPE}-dev:latest"
+            docker push "${DOCKER_IMAGE_PREFIX}${BUILD_TYPE}-dev:latest"
+        fi
     done
 
     # This script tests the docker examples.


### PR DESCRIPTION
Signed-off-by: Lizan Zhou <lizan@tetrate.io>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
